### PR TITLE
Knot.x Launcher distribution

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,0 +1,8 @@
+########### Modules to start ###########
+# Modules array specify a list of verticles to be started by Knot.x.
+# Each line should have a form of <alias>=<verticle-class-name>
+# where alias is just a name that you can use later in order to define configuration for the module
+# verticle-class-name is a fully qualified class name of the verticle.
+#
+# This array is filled in included files.
+modules = []

--- a/conf/bootstrap.json
+++ b/conf/bootstrap.json
@@ -1,0 +1,15 @@
+{
+  "configRetrieverOptions": {
+    "scanPeriod": 5000,
+    "stores": [
+      {
+        "type": "file",
+        "format": "conf",
+        "config": {
+          "path": "conf/application.conf"
+        },
+        "optional": false
+      }
+    ]
+  }
+}

--- a/gradle/javaAndUnitTests.gradle.kts
+++ b/gradle/javaAndUnitTests.gradle.kts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+subprojects {
+    plugins.withId("java-library") {
+        tasks.withType<JavaCompile>().configureEach {
+            with(options) {
+                sourceCompatibility = "1.8"
+                targetCompatibility = "1.8"
+                compilerArgs = listOf("-parameters")
+                encoding = "UTF-8"
+            }
+        }
+
+        tasks.withType<Test>().configureEach {
+            environment("vertx.logger-delegate-factory-class-name", "io.vertx.core.logging.SLF4JLogDelegateFactory")
+
+            failFast = true
+            useJUnitPlatform()
+            testLogging {
+                events = setOf(TestLogEvent.FAILED)
+                exceptionFormat = TestExceptionFormat.SHORT
+            }
+
+            dependencies {
+                "testImplementation"("org.junit.jupiter:junit-jupiter-api")
+                "testRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine")
+            }
+        }
+    }
+}

--- a/src/main/resources/io.knotx.logging.logback/access-file-appender.xml
+++ b/src/main/resources/io.knotx.logging.logback/access-file-appender.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 Knot.x Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+File appender logback configuration provided for import
+-->
+
+<included>
+  <appender name="ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_ACCESS_LOG_PATTERN}</pattern>
+    </encoder>
+    <file>${ACCESS_LOG_FILE}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${ACCESS_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+      <maxFileSize>${ACCESS_LOG_FILE_MAX_SIZE:-10MB}</maxFileSize>
+      <maxHistory>${ACCESS_LOG_FILE_MAX_HISTORY:-0}</maxHistory>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/src/main/resources/io.knotx.logging.logback/access.xml
+++ b/src/main/resources/io.knotx.logging.logback/access.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 Knot.x Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+File appender logback configuration for knotx access logs provided for import
+-->
+
+<included>
+  <property name="FILE_ACCESS_LOG_PATTERN" value="%msg%n"/>
+  <property name="ACCESS_LOG_FILE" value="${LOG_PATH}/knotx-access.log"/>
+  <include resource="io/knotx/logging/logback/access-file-appender.xml"/>
+
+  <logger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="INFO" additivity="false">
+    <appender-ref ref="ACCESS" />
+  </logger>
+</included>

--- a/src/main/resources/io.knotx.logging.logback/base.xml
+++ b/src/main/resources/io.knotx.logging.logback/base.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 Knot.x Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+Base logback configuration for knot.x
+-->
+<included>
+  <include resource="io/knotx/logging/logback/defaults.xml"/>
+  <include resource="io/knotx/logging/logback/console-appender.xml"/>
+  <include resource="io/knotx/logging/logback/file-appender.xml"/>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+</included>

--- a/src/main/resources/io.knotx.logging.logback/console-appender.xml
+++ b/src/main/resources/io.knotx.logging.logback/console-appender.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 Knot.x Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+Console appender logback configuration provided for import
+-->
+
+<included>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_KNOTX_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+</included>

--- a/src/main/resources/io.knotx.logging.logback/defaults.xml
+++ b/src/main/resources/io.knotx.logging.logback/defaults.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 Knot.x Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+Default logback configuration provided for import
+-->
+
+<included>
+  <property name="LOG_PATH" value="${LOG_PATH:-./logs}"/>
+
+  <property name="CONSOLE_KNOTX_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
+  <property name="FILE_KNOTX_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
+
+  <property name="KNOTX_LOG_FILE" value="${LOG_PATH}/knotx.log"/>
+
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="io.vertx" level="ERROR"/>
+  <logger name="io.knotx" level="INFO"/>
+  <logger name="com.hazelcast" level="INFO"/>
+</included>

--- a/src/main/resources/io.knotx.logging.logback/file-appender.xml
+++ b/src/main/resources/io.knotx.logging.logback/file-appender.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 Knot.x Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+File appender logback configuration provided for import
+-->
+
+<included>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_KNOTX_LOG_PATTERN}</pattern>
+    </encoder>
+    <file>${KNOTX_LOG_FILE}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${KNOTX_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+      <maxFileSize>${KNOTX_LOG_FILE_MAX_SIZE:-10MB}</maxFileSize>
+      <maxHistory>${KNOTX_LOG_FILE_MAX_HISTORY:-0}</maxHistory>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/src/main/resources/io.knotx.logging.logback/netty-file-appender.xml
+++ b/src/main/resources/io.knotx.logging.logback/netty-file-appender.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 Knot.x Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+File appender logback configuration provided for import
+-->
+
+<included>
+  <appender name="NETTY" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_NETTY_LOG_PATTERN}</pattern>
+    </encoder>
+    <file>${NETTY_LOG_FILE}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${NETTY_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+      <maxFileSize>${NETTY_LOG_FILE_MAX_SIZE:-10MB}</maxFileSize>
+      <maxHistory>${NETTY_LOG_FILE_MAX_HISTORY:-0}</maxHistory>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/src/main/resources/io.knotx.logging.logback/netty.xml
+++ b/src/main/resources/io.knotx.logging.logback/netty.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2019 Knot.x Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
+File appender logback configuration for netty debug logs provided for import
+-->
+
+<included>
+  <property name="FILE_NETTY_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
+  <property name="NETTY_LOG_FILE" value="${LOG_PATH}/knotx-netty.log"/>
+  <include resource="io/knotx/logging/logback/netty-file-appender.xml"/>
+
+  <logger name="io.netty.handler.logging.LoggingHandler" level="DEBUG" additivity="false">
+    <appender-ref ref="NETTY" />
+  </logger>
+</included>


### PR DESCRIPTION
Knotx Launcher is a starting module for all Knot.x-based projects.

## Description
```
./gradlew clean publishToMavenLocal
unzip knotx-launcher-2.0.0-SNAPSHOT.zip
cd knotx-launcher-2.0.0-SNAPSHOT
./bin/start run-knotx
```

## Motivation and Context
 All modules in Knot.x can be replaced with custom implementation. This is the reason we deliver Knot.x Launcher as a separate ZIP distribution that can be reused in projects. Please note that Launcher module provides logger configuration too.

## Upgrade notes (if appropriate)
Logger configuration is moved from Server to Launcher module.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
