### PR TITLE
Remove deprecated API usage, Vert.x 3.8.1

### DIFF
--- a/src/main/java/io/knotx/launcher/KnotxCommandFactory.java
+++ b/src/main/java/io/knotx/launcher/KnotxCommandFactory.java
@@ -26,6 +26,6 @@ public class KnotxCommandFactory extends DefaultCommandFactory<KnotxCommand> {
    * Creates a new instance of {@link KnotxCommandFactory}.
    */
   public KnotxCommandFactory() {
-    super(KnotxCommand.class);
+    super(KnotxCommand.class, KnotxCommand::new);
   }
 }


### PR DESCRIPTION
Upgrade Vert.x from 3.7.1 to 3.8.1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
