### PR TITLE
Use try-with-resources instead closeQuietly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to `knotx-launcher` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-38](https://github.com/Knotx/knotx-launcher/pull/38) - Use try-with-resources statement ensures that resource is close (see also https://github.com/vert-x3/vertx-config/pull/115)
                 
 ## 2.2.0
+No notable changes
 
 ## 2.1.0
 - [PR-19](https://github.com/Knotx/knotx-launcher/pull/19) - Remove deprecated API usage, Vert.x 3.8.1.

--- a/src/main/java/io/knotx/launcher/config/ConfProcessor.java
+++ b/src/main/java/io/knotx/launcher/config/ConfProcessor.java
@@ -15,8 +15,6 @@
  */
 package io.knotx.launcher.config;
 
-import static io.vertx.config.impl.spi.PropertiesConfigProcessor.closeQuietly;
-
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigIncludeContext;
@@ -77,8 +75,7 @@ public class ConfProcessor implements ConfigProcessor {
     // Indeed, HOCON resolution can read others files (includes).
     vertx.executeBlocking(
         future -> {
-          Reader reader = new StringReader(input.toString("UTF-8"));
-          try {
+          try (Reader reader = new StringReader(input.toString("UTF-8"))){
             Config conf = ConfigFactory.parseReader(reader,
                 ConfigParseOptions.defaults().appendIncluder(new KnotxConfIncluder(configuration)));
 
@@ -91,8 +88,6 @@ public class ConfProcessor implements ConfigProcessor {
             future.complete(json);
           } catch (Exception e) {
             future.fail(e);
-          } finally {
-            closeQuietly(reader);
           }
         },
         handler


### PR DESCRIPTION
## Description
Use try-with-resources instead `closeQuietly` to close StringReader.

## Motivation and Context
In Vert.x 3.9.1 `closeQuietly` was removed, see https://github.com/vert-x3/vertx-config/pull/115.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/Knotx/knotx/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
